### PR TITLE
Undoing change to projection matrix.

### DIFF
--- a/examples/directx11_example/imgui_impl_dx11.cpp
+++ b/examples/directx11_example/imgui_impl_dx11.cpp
@@ -112,7 +112,7 @@ void ImGui_ImplDX11_RenderDrawLists(ImDrawData* draw_data)
             { 2.0f/(R-L),   0.0f,           0.0f,       0.0f },
             { 0.0f,         2.0f/(T-B),     0.0f,       0.0f },
             { 0.0f,         0.0f,           0.5f,       0.0f },
-            { (R+L)/(L-R),  (T+B)/(B-T),    0.0f,       1.0f },
+            { (R+L)/(L-R),  (T+B)/(B-T),    0.5f,       1.0f },
         };
         memcpy(&constant_buffer->mvp, mvp, sizeof(mvp));
         ctx->Unmap(g_pVertexConstantBuffer, 0);


### PR DESCRIPTION
I don't know if there is some assumption in the code that the matrix is how it is, so am leaving it alone. Just changing the depth test should be sufficient.